### PR TITLE
Removing `main` from `dbuf-core`

### DIFF
--- a/dbuf-core/src/main.rs
+++ b/dbuf-core/src/main.rs
@@ -1,3 +1,0 @@
-fn main() {
-    println!("Hello, world!");
-}


### PR DESCRIPTION
The purpose of `dbuf-core` is to be a library crate for other crates, so I removed `main.rs`.