### PR TITLE
Migrating from rc to arc

### DIFF
--- a/dbuf-core/src/ast/elaborated.rs
+++ b/dbuf-core/src/ast/elaborated.rs
@@ -75,6 +75,5 @@ pub enum TypeExpression<Str> {
 /// Shared list of value subexpressions. There are no type subexpressions for now.
 pub type ValueExprs<S> = Rec<[ValueExpression<S>]>;
 
-/// Expression uses Rc for recursion.
-/// Consider migrating to Arc when going multicore.
-pub type Rec<T> = std::rc::Rc<T>;
+/// Expression uses Arc for recursion.
+pub type Rec<T> = std::sync::Arc<T>;

--- a/dbuf-core/src/ast/parsed/mod.rs
+++ b/dbuf-core/src/ast/parsed/mod.rs
@@ -91,6 +91,5 @@ pub enum PatternNode<Loc, Str, Pattern> {
     Underscore,
 }
 
-/// Parsed expressions and patterns use Rc for recursion.
-/// Consider switching to Arc when going multicore.
-pub type Rec<T> = std::rc::Rc<T>;
+/// Parsed expressions and patterns use Arc for recursion.
+pub type Rec<T> = std::sync::Arc<T>;


### PR DESCRIPTION
`dbuf-lsp` is multi-core application, which needs multiple read accesses to ASTs from different threads. So Sync+Send traits are vital.