### PR TITLE
fix add logic

### DIFF
--- a/dbuf-core/src/ast/parsed/location.rs
+++ b/dbuf-core/src/ast/parsed/location.rs
@@ -15,9 +15,16 @@ impl Add<Offset> for Offset {
     type Output = Self;
 
     fn add(self, rhs: Offset) -> Self::Output {
-        Self {
-            lines: self.lines + rhs.lines,
-            columns: self.columns + rhs.columns,
+        if rhs.lines == 0 {
+            Self {
+                lines: self.lines,
+                columns: self.columns + rhs.columns,
+            }
+        } else {
+            Self {
+                lines: self.lines + rhs.lines,
+                columns: rhs.columns,
+            }
         }
     }
 }


### PR DESCRIPTION
Add logic was incorrect.

Expect:
```
1: Pos(1, 1) + Offset(0, 5) = Pos(1, 6)
2: Pos(1, 1) + Offset(1, 0) = Pos(2, 0)
3: Pos(1, 1) + Offset(1, 1) = Pos(2, 1) 
```