### PR TITLE
Update checkout

### DIFF
--- a/.github/workflows/code_check.yml
+++ b/.github/workflows/code_check.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: "${{ env.RUST_TOOLCHAIN }}"
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
@@ -66,7 +66,7 @@ jobs:
             args: "--all-features"
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:


### PR DESCRIPTION
Updating checkout version from v4 to v6. Change log can be found [here](https://github.com/actions/checkout). Changed:
* Using node 24 instead of node 20.
* Improved security.